### PR TITLE
PhotCal/Sextractor cooperation

### DIFF
--- a/winterdrp/errors/__init__.py
+++ b/winterdrp/errors/__init__.py
@@ -1,5 +1,10 @@
 from winterdrp.paths import base_name_key
 
+
+class ProcessorError(BaseException):
+    pass
+
+
 class ErrorReport:
 
     def __init__(

--- a/winterdrp/processors/astromatic/sextractor/sextractor.py
+++ b/winterdrp/processors/astromatic/sextractor/sextractor.py
@@ -68,16 +68,13 @@ class Sextractor(BaseProcessor):
 
             det_image, measure_image, det_header, measure_header = None, None, None, None
             if self.dual:
-                try:
-                    det_header = headers[i][0]
-                    measure_header = headers[i][1]
-                    det_image = images[i][0]
-                    measure_image = images[i][1]
-                    header = det_header
-                    data = det_image
-                    self.gain = measure_header["GAIN"]
-                except:
-                    ValueError()
+                det_header = headers[i][0]
+                measure_header = headers[i][1]
+                det_image = images[i][0]
+                measure_image = images[i][1]
+                header = det_header
+                data = det_image
+                self.gain = measure_header["GAIN"]
 
             temp_path = get_temp_path(sextractor_out_dir, header["BASENAME"])
 

--- a/winterdrp/processors/base_processor.py
+++ b/winterdrp/processors/base_processor.py
@@ -15,6 +15,9 @@ from winterdrp.errors import ErrorReport
 
 logger = logging.getLogger(__name__)
 
+class PrerequisiteError(BaseException):
+    pass
+
 
 class BaseProcessor:
 

--- a/winterdrp/processors/photcal.py
+++ b/winterdrp/processors/photcal.py
@@ -2,10 +2,9 @@ import astropy.io.fits
 import numpy as np
 import os
 import logging
-from winterdrp.processors.base_processor import BaseProcessor, ProcessorWithCache
-from winterdrp.paths import get_output_dir, copy_temp_file, get_temp_path, get_untemp_path
+from winterdrp.processors.base_processor import BaseProcessor
+from winterdrp.paths import get_output_dir, copy_temp_file
 from collections.abc import Callable
-from winterdrp.paths import cal_output_dir
 from winterdrp.catalog.base_catalog import BaseCatalog
 from winterdrp.processors.astromatic.sextractor.sextractor import Sextractor, sextractor_header_key
 from winterdrp.utils.ldac_tools import get_table_from_ldac
@@ -165,13 +164,13 @@ class PhotCalibrator(BaseProcessor):
             logger.error(err)
             raise ValueError
 
-        # sextractor_steps = np.array(self.preceding_steps)[mask]
-        #
-        # for processor in sextractor_steps:
-        #     print(processor)
-        #
-        # raise
-        #
-        # check_fwhm
+        sextractor_steps = np.array(self.preceding_steps)[mask]
+
+        for processor in sextractor_steps:
+            print(processor)
+
+        raise
+
+        check_fwhm
 
 

--- a/winterdrp/processors/photcal.py
+++ b/winterdrp/processors/photcal.py
@@ -179,7 +179,7 @@ class PhotCalibrator(BaseProcessor):
         for param in REQUIRED_PARAMETERS:
             if param not in sextractor_params:
                 err = f"Missing parameter: {self.__module__} requires {param} to run, " \
-                      f"but this parameter was not found in sextractor config file {latest_sextractor_param_path}. " \
+                      f"but this parameter was not found in sextractor config file '{latest_sextractor_param_path}' . " \
                       f"Please add the parameter to this list!"
                 logger.error(err)
                 raise PrerequisiteError(err)


### PR DESCRIPTION
This PR changes some error handling for photcal. The big difference is that the processor will check the parameter file of the preceding Sextractor processor, and make sure all required parameters are there. If not, it'll give a clear error telling users to add parameters to the file. 

Also changed the script to actually raise processing errors rather than return text info. These errors can then be handled properly by the `error handler`