### PR TITLE
Check for kowalski creds only if using it

### DIFF
--- a/winterdrp/catalog/base_catalog.py
+++ b/winterdrp/catalog/base_catalog.py
@@ -125,12 +125,13 @@ class BaseXMatchCatalog:
 class BaseKowalskiXMatch(BaseXMatchCatalog):
 
     def __init__(self,
+                 kowalski: Kowalski = None,
                  max_time_ms: float = 10000,
                  *args,
                  **kwargs):
         super(BaseKowalskiXMatch, self).__init__(*args,**kwargs)
         self.max_time_ms = max_time_ms
-        self.kowalski = None
+        self.kowalski = kowalski
 
     def get_kowalski(self) -> Kowalski:
         protocol, host, port = "https", "kowalski.caltech.edu", 443
@@ -189,7 +190,8 @@ class BaseKowalskiXMatch(BaseXMatchCatalog):
         return data[self.catalog_name]
 
     def query(self, coords) -> dict:
-        self.kowalski = self.get_kowalski()
+        if self.kowalski is None:
+            self.kowalski = self.get_kowalski()
         logger.info('Querying kowalski')
         data = self.near_query_kowalski(coords)
         return data

--- a/winterdrp/pipelines/wirc_imsub/wirc_imsub_pipeline.py
+++ b/winterdrp/pipelines/wirc_imsub/wirc_imsub_pipeline.py
@@ -92,38 +92,6 @@ def detect_candidates_sextractor():
     pass
 
 
-def get_kowalski():
-    protocol, host, port = "https", "kowalski.caltech.edu", 443
-
-    token_kowalski = os.environ.get("kowalski_token")
-
-    if token_kowalski is not None:
-        logger.debug("Using kowalski token")
-
-        k = Kowalski(token=token_kowalski, protocol=protocol, host=host, port=port)
-
-    else:
-
-        username_kowalski = os.environ.get('kowalski_user')
-        password_kowalski = os.environ.get('kowalski_pwd')
-    
-        if username_kowalski is None:
-            err = 'Kowalski username not provided, please run export kowalski_user=<user>'
-            logger.error(err)
-            raise ValueError
-        if password_kowalski is None:
-            err = 'Kowalski password not provided, please run export KOWALSKI_PWD=<user>'
-            logger.error(err)
-            raise ValueError
-
-        k = Kowalski(username=username_kowalski, password=password_kowalski, protocol=protocol, host=host, port=port)
-
-    connection_ok = k.ping()
-    logger.info(f'Connection OK?: {connection_ok}')
-
-    return k
-
-
 class WircImsubPipeline(Pipeline):
     name = "wirc_imsub"
 
@@ -170,12 +138,12 @@ class WircImsubPipeline(Pipeline):
             PSFPhotometry(),
             DataframeWriter(output_dir_name='candidates'),
             XMatch(
-                catalog=TMASS(kowalski=get_kowalski()),
+                catalog=TMASS(),
                 num_stars=3,
                 search_radius_arcsec=30
             ),
             XMatch(
-                catalog=PS1(kowalski=get_kowalski()),
+                catalog=PS1(),
                 num_stars=3,
                 search_radius_arcsec=30
             ),

--- a/winterdrp/pipelines/wirc_imsub/wirc_imsub_pipeline.py
+++ b/winterdrp/pipelines/wirc_imsub/wirc_imsub_pipeline.py
@@ -93,21 +93,34 @@ def detect_candidates_sextractor():
 
 
 def get_kowalski():
-    # secrets = ascii.read('/Users/viraj/ztf_utils/secrets.csv', format='csv')
-    username_kowalski = os.environ.get('kowalski_user')
-    password_kowalski = os.environ.get('kowalski_pwd')
-    if username_kowalski is None:
-        err = 'Kowalski username not provided, please run export kowalski_user=<user>'
-        logger.error(err)
-        raise ValueError
-    if password_kowalski is None:
-        err = 'Kowalski password not provided, please run export KOWALSKI_PWD=<user>'
-        logger.error(err)
-        raise ValueError
     protocol, host, port = "https", "kowalski.caltech.edu", 443
-    k = Kowalski(username=username_kowalski, password=password_kowalski, protocol=protocol, host=host, port=port)
+
+    token_kowalski = os.environ.get("kowalski_token")
+
+    if token_kowalski is not None:
+        logger.debug("Using kowalski token")
+
+        k = Kowalski(token=token_kowalski, protocol=protocol, host=host, port=port)
+
+    else:
+
+        username_kowalski = os.environ.get('kowalski_user')
+        password_kowalski = os.environ.get('kowalski_pwd')
+    
+        if username_kowalski is None:
+            err = 'Kowalski username not provided, please run export kowalski_user=<user>'
+            logger.error(err)
+            raise ValueError
+        if password_kowalski is None:
+            err = 'Kowalski password not provided, please run export KOWALSKI_PWD=<user>'
+            logger.error(err)
+            raise ValueError
+
+        k = Kowalski(username=username_kowalski, password=password_kowalski, protocol=protocol, host=host, port=port)
+
     connection_ok = k.ping()
-    logger.info(f'Connection OK: {connection_ok}')
+    logger.info(f'Connection OK?: {connection_ok}')
+
     return k
 
 


### PR DESCRIPTION
More tolerant towards kowalski credentials, can run other pipelines where kowalski is not being used without setting kowalski credentials.
Also added the option to use a token instead of user/pwd for kowalski