### PR TITLE
Sort path list in ImageLoader

### DIFF
--- a/winterdrp/pipelines/wirc/wirc_pipeline.py
+++ b/winterdrp/pipelines/wirc/wirc_pipeline.py
@@ -69,7 +69,8 @@ def load_raw_wirc_image(
         if "PROGID" not in header.keys():
             header["PROGID"] = 0
 
-        data[data == 0] = np.nan
+        data = data.astype(float)
+        data[data == 0.] = np.nan
     return data, header
 
 

--- a/winterdrp/processors/utils/image_loader.py
+++ b/winterdrp/processors/utils/image_loader.py
@@ -71,7 +71,7 @@ class ImageLoader(BaseImageProcessor):
             os.path.join(self.night_sub_dir, self.input_sub_dir)
         )
 
-        img_list = glob(f'{input_dir}/*.fits')
+        img_list = sorted(glob(f'{input_dir}/*.fits'))
 
         logger.info(f"Loading from {input_dir}, with {len(img_list)} images")
 


### PR DESCRIPTION
Now loop over `sorted(img_list)`, meaning that images generally get loaded up in numerically ascending order