### PR TITLE
Add Error Handling

### DIFF
--- a/winterdrp/errors/__init__.py
+++ b/winterdrp/errors/__init__.py
@@ -1,8 +1,10 @@
 from winterdrp.paths import base_name_key
+from astropy.time import Time
 
 
 class ProcessorError(BaseException):
     pass
+
 
 class ErrorReport:
 
@@ -10,12 +12,13 @@ class ErrorReport:
             self,
             error,
             processor_name,
-            images,
-            headers
+            contents: list[str]
     ):
         self.error = error
         self.processor_name = processor_name
-        self.filenames = [h[base_name_key] for h in headers]
+        self.contents = contents
+        self.t_error = Time.now()
 
     def generate_log_message(self):
-        return "You messed up somewhere :)"
+        return f"Error for processor {self.processor_name} at time {self.t_error} UT: " \
+               f"{type(self.error).__name__} affected batch of length {len(self.contents)}."

--- a/winterdrp/processors/base_processor.py
+++ b/winterdrp/processors/base_processor.py
@@ -41,7 +41,6 @@ class ImageHandler:
         logger.info(f"Saving to {path}")
         save_to_path(data, header, path)
 
-
     def save_mask(
             self,
             data: np.ndarray,
@@ -58,6 +57,11 @@ class ImageHandler:
     def get_hash(headers: list[astropy.io.fits.Header]):
         key = "".join(sorted([x[base_name_key] + x[proc_history_key] for x in headers]))
         return hashlib.sha1(key.encode()).hexdigest()
+
+    def image_batch_error_report(self, exception: Exception, batch):
+        print(len(batch))
+        contents = [x[base_name_key] for x in batch[1]]
+        return ErrorReport(exception, self.__module__, contents)
 
 
 class BaseProcessor:
@@ -120,8 +124,8 @@ class BaseProcessor:
             try:
                 batch = self.apply(batch)
                 passed_batches.append(batch)
-            except ProcessingError as e:
-                err = ErrorReport(e, self.__module__, batch)
+            except Exception as e:
+                err = self.generate_error_report(e, batch)
                 logger.error(err.generate_log_message())
                 failures.append(err)
 
@@ -130,6 +134,9 @@ class BaseProcessor:
         return batches, failures
 
     def apply(self, batch):
+        raise NotImplementedError
+
+    def generate_error_report(self, exception: Exception, batch) -> ErrorReport:
         raise NotImplementedError
 
 
@@ -165,6 +172,9 @@ class BaseImageProcessor(BaseProcessor, ImageHandler, ABC):
             header['REDTIME'] = str(datetime.datetime.now())
             header["REDSOFT"] = "winterdrp"
         return headers
+
+    def generate_error_report(self, exception: Exception, batch) -> ErrorReport:
+        return self.image_batch_error_report(exception, batch)
 
 
 class ProcessorWithCache(BaseImageProcessor, ABC):

--- a/winterdrp/processors/base_processor.py
+++ b/winterdrp/processors/base_processor.py
@@ -59,7 +59,6 @@ class ImageHandler:
         return hashlib.sha1(key.encode()).hexdigest()
 
     def image_batch_error_report(self, exception: Exception, batch):
-        print(len(batch))
         contents = [x[base_name_key] for x in batch[1]]
         return ErrorReport(exception, self.__module__, contents)
 
@@ -296,3 +295,7 @@ class BaseDataframeProcessor(BaseProcessor, ABC):
             candidate_table: pd.DataFrame,
     ) -> pd.DataFrame:
         raise NotImplementedError
+
+    def generate_error_report(self, exception: Exception, batch: pd.DataFrame):
+        contents = batch[base_name_key]
+        return ErrorReport(exception, self.__module__, contents)


### PR DESCRIPTION
Add some basic error handling, to be improved in future. Now, processors will loop over batches, and return both batches and Error reports. A batch will be returned if the input batch that was successfully processed, otherwise an Error report will summarise the first encountered error for that batches. The pipelines can keep track of these error reports.