### PR TITLE
Add ErrorStack

### DIFF
--- a/winterdrp/__main__.py
+++ b/winterdrp/__main__.py
@@ -57,6 +57,12 @@ parser.add_argument(
     action='store_true',
     default=False
 )
+parser.add_argument(
+    "-e",
+    "--errorpath",
+    default="errorlog.txt",
+    help="Path to output errors"
+)
 # parser.add_argument(
 #     '-skipfail',
 #     help='If processing of one image set fails, proceed with other objects/filters',
@@ -94,6 +100,6 @@ pipe = get_pipeline(
     night=args.night,
 )
 
-pipe.reduce_images([[[], []]])
+pipe.reduce_images([[[], []]], output_error_path=args.errorpath)
 
 logger.info('End of winterdrp execution')

--- a/winterdrp/errors/__init__.py
+++ b/winterdrp/errors/__init__.py
@@ -23,20 +23,11 @@ class ErrorReport:
         self.contents = contents
         self.t_error = Time.now()
 
-    def generate_log_message(self):
+    def generate_log_message(self) -> str:
         return f"Error for processor {self.processor_name} at time {self.t_error} UT: " \
                f"{type(self.error).__name__} affected batch of length {len(self.contents)}."
 
-    def generate_full_traceback(self):
-
-        # print(vars(self.error))
-        # print(self.error)
-        # print(dir(self.error))
-        # # print(self.error.with_traceback())
-        # print(self.error.__traceback__)
-        # print(traceback.format_tb(self.error.__traceback__))
-        # print("um")
-
+    def generate_full_traceback(self) -> str:
         msg = f"Error for processor {self.processor_name} at time {self.t_error} UT: \n " \
               f"{''.join(traceback.format_tb(self.error.__traceback__))} \n " \
               f"This error affected the following files: {self.contents} \n"

--- a/winterdrp/errors/__init__.py
+++ b/winterdrp/errors/__init__.py
@@ -1,6 +1,9 @@
 from winterdrp.paths import base_name_key
 import traceback
 from astropy.time import Time
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class ProcessorError(BaseException):
@@ -25,23 +28,72 @@ class ErrorReport:
                f"{type(self.error).__name__} affected batch of length {len(self.contents)}."
 
     def generate_full_traceback(self):
+
+        # print(vars(self.error))
+        # print(self.error)
+        # print(dir(self.error))
+        # # print(self.error.with_traceback())
+        # print(self.error.__traceback__)
+        # print(traceback.format_tb(self.error.__traceback__))
+        # print("um")
+
         msg = f"Error for processor {self.processor_name} at time {self.t_error} UT: \n " \
-              f"{traceback.print_exception(self.error)} \n " \
+              f"{''.join(traceback.format_tb(self.error.__traceback__))} \n " \
               f"This error affected the following files: {self.contents} \n"
         return msg
 
 
-def summarise_error_reports(
-        reports: list[ErrorReport],
-        output_path=None
-) -> str:
-    summary = "",
+class ErrorStack:
 
-    for report in reports:
-        summary += report.generate_full_traceback()
+    def __init__(
+            self,
+            reports: list[ErrorReport] = None
+    ):
+        self.reports = []
+        self.failed_images = []
 
-    if output_path is not None:
-        with open(output_path, "wb") as f:
-            f.write(summary)
+        if reports is not None:
+            for report in reports:
+                self.add_report(report)
 
-    return summary
+    def add_report(self, report: ErrorReport):
+        self.reports.append(report)
+        all_failed_images = self.failed_images + report.contents
+        self.failed_images = sorted(list(set(all_failed_images)))
+
+    def __add__(self, other):
+        for report in other.reports:
+            self.add_report(report)
+        return self
+
+    def summarise_error_stack(
+            self,
+            output_path=None
+    ) -> str:
+
+        summary = f"Error report summarising {len(self.reports)} errors. \n" \
+
+        if len(self.reports) > 0:
+
+            summary += f"The following images were affected by at least one error during processing \n: " \
+                       f"{self.failed_images} \n \n" \
+                       f"Summarising each error: \n"
+
+            logger.error(f"Found {len(self.reports)} errors caught by code.")
+
+            for report in self.reports:
+                summary += str(report.generate_full_traceback())
+
+            if output_path is not None:
+
+                logger.error(f"Saving tracebacks of caught errors to {output_path}")
+
+                with open(output_path, "w") as f:
+                    f.write(summary)
+
+        else:
+            msg = "No raised errors found in processing"
+            logger.info(msg)
+            summary += f"\n {msg}"
+
+        return summary

--- a/winterdrp/errors/__init__.py
+++ b/winterdrp/errors/__init__.py
@@ -1,4 +1,5 @@
 from winterdrp.paths import base_name_key
+import traceback
 from astropy.time import Time
 
 
@@ -22,3 +23,25 @@ class ErrorReport:
     def generate_log_message(self):
         return f"Error for processor {self.processor_name} at time {self.t_error} UT: " \
                f"{type(self.error).__name__} affected batch of length {len(self.contents)}."
+
+    def generate_full_traceback(self):
+        msg = f"Error for processor {self.processor_name} at time {self.t_error} UT: \n " \
+              f"{traceback.print_exception(self.error)} \n " \
+              f"This error affected the following files: {self.contents} \n"
+        return msg
+
+
+def summarise_error_reports(
+        reports: list[ErrorReport],
+        output_path=None
+) -> str:
+    summary = "",
+
+    for report in reports:
+        summary += report.generate_full_traceback()
+
+    if output_path is not None:
+        with open(output_path, "wb") as f:
+            f.write(summary)
+
+    return summary

--- a/winterdrp/processors/base_processor.py
+++ b/winterdrp/processors/base_processor.py
@@ -14,7 +14,7 @@ import pandas as pd
 from winterdrp.io import save_to_path, open_fits
 from winterdrp.paths import cal_output_sub_dir, get_mask_path, latest_save_key, latest_mask_save_key, get_output_path,\
     ProcessingError, base_name_key, proc_history_key
-from winterdrp.errors import ErrorReport
+from winterdrp.errors import ErrorReport, ErrorStack
 
 logger = logging.getLogger(__name__)
 
@@ -113,10 +113,10 @@ class BaseProcessor:
     def base_apply(
             self,
             batches: list
-    ) -> tuple[list, list[ErrorReport]]:
+    ) -> tuple[list, ErrorStack]:
 
         passed_batches = []
-        failures = []
+        err_stack = ErrorStack()
 
         for i, batch in enumerate(batches):
 
@@ -126,11 +126,11 @@ class BaseProcessor:
             except Exception as e:
                 err = self.generate_error_report(e, batch)
                 logger.error(err.generate_log_message())
-                failures.append(err)
+                err_stack.add_report(err)
 
         batches = self.update_batches(passed_batches)
 
-        return batches, failures
+        return batches, err_stack
 
     def apply(self, batch):
         raise NotImplementedError


### PR DESCRIPTION
Adds a new class, `ErrorStack` which contains multiple `ErrorReport` objects.

You can add them together! E.g:
```
err_stack_full = err_stack_a + err_stack_b
```
or 
```
# Empty Stack
full_err_stack = ErrorStack()

# Loop and make more error stacks
for x in loop:
    new_err_stack = some_function()
    full_err_stack += new_err_stack
```

The ErrorStack tracks the full list of images for which at least one processing error occurred. It can also summarise the errors as a string  with `ErrorStack.summarise_error_stack()`, and that can be written to a file for easy inspection.