### PR TITLE
Add functionality for tracking internal python exceptions

### DIFF
--- a/winterdrp/errors/__init__.py
+++ b/winterdrp/errors/__init__.py
@@ -76,7 +76,8 @@ class ErrorStack:
 
     def summarise_error_stack(
             self,
-            output_path=None
+            output_path=None,
+            verbose: bool = True
     ) -> str:
 
         is_known_error = [x.known_error_bool for x in self.reports]
@@ -96,7 +97,10 @@ class ErrorStack:
             logger.error(f"Found {len(self.reports)} errors caught by code.")
 
             for report in self.reports:
-                summary += str(report.generate_full_traceback())
+                if verbose:
+                    summary += str(report.generate_full_traceback())
+                else:
+                    summary += report.generate_log_message()
 
             if output_path is not None:
 

--- a/winterdrp/pipelines/base_pipeline.py
+++ b/winterdrp/pipelines/base_pipeline.py
@@ -94,7 +94,6 @@ class Pipeline:
             batches, new_err_stack = processor.base_apply(
                 batches
             )
-            print(new_err_stack, err_stack)
             err_stack += new_err_stack
 
         err_stack.summarise_error_stack(output_path=output_error_path)

--- a/winterdrp/pipelines/wirc/wirc_pipeline.py
+++ b/winterdrp/pipelines/wirc/wirc_pipeline.py
@@ -118,7 +118,7 @@ class WircPipeline(Pipeline):
             SkyFlatCalibrator(),
             NightSkyMedianCalibrator(),
             ImageSelector(
-                ("object", "ZTF21acbnfos"),
+                ("object", "ZTF21aagppzg"),
                 ("filter", "J")
             ),
             AutoAstrometry(catalog="tmc"),

--- a/winterdrp/pipelines/wirc/wirc_pipeline.py
+++ b/winterdrp/pipelines/wirc/wirc_pipeline.py
@@ -137,6 +137,29 @@ class WircPipeline(Pipeline):
             ),
             ImageSaver(output_dir_name="final"),
             PhotCalibrator(ref_catalog_generator=wirc_photometric_catalog_generator),
+            # ImageDebatcher(),
+            # ImageBatcher(split_key="filter"),
+            # SkyFlatCalibrator(),
+            # NightSkyMedianCalibrator(),
+            # ImageSelector(
+            #     ("object", "ZTF21acbnfos"),
+            # ),
+            # AutoAstrometry(catalog="tmc"),
+            # Sextractor(
+            #     output_sub_dir="postprocess",
+            #     **sextractor_astrometry_config
+            # ),
+            # Scamp(
+            #     ref_catalog_generator=wirc_astrometric_catalog_generator,
+            #     scamp_config_path=scamp_fp_path,
+            # ),
+            # Swarp(swarp_config_path=swarp_sp_path),
+            # Sextractor(
+            #     output_sub_dir="final_sextractor",
+            #     **sextractor_astrometry_config
+            # ),
+            # ImageSaver(output_dir_name="final"),
+            # PhotCalibrator(ref_catalog_generator=wirc_photometric_catalog_generator),
         ]
     }
 

--- a/winterdrp/pipelines/wirc/wirc_pipeline.py
+++ b/winterdrp/pipelines/wirc/wirc_pipeline.py
@@ -19,6 +19,7 @@ from winterdrp.downloader.caltech import download_via_ssh
 from winterdrp.processors.utils.image_loader import ImageLoader
 from winterdrp.processors.utils.image_selector import ImageSelector, ImageBatcher, ImageDebatcher
 from winterdrp.paths import coadd_key, proc_history_key
+from winterdrp.processors.csvlog import CSVLog
 import logging
 
 logger = logging.getLogger(__name__)
@@ -99,6 +100,7 @@ class WircPipeline(Pipeline):
                 input_sub_dir="raw",
                 load_image=load_raw_wirc_image
             ),
+            CSVLog(),
             MaskPixels(mask_path=wirc_mask_path),
             ImageBatcher(split_key="exptime"),
             DarkCalibrator(),


### PR DESCRIPTION
Adds an option to track which python errors were raised by the code/which were not. Essential component of #49. The ErrorStack/ErrorReport summaries will now track this info.