### PR TITLE
Add Prebuiltcache Processor

### DIFF
--- a/winterdrp/processors/base_processor.py
+++ b/winterdrp/processors/base_processor.py
@@ -253,6 +253,25 @@ class ProcessorWithCache(BaseImageProcessor, ABC):
         raise NotImplementedError
 
 
+class ProcessorPremadeCache(ProcessorWithCache, ABC):
+
+    def __init__(
+            self,
+            master_image_path: str,
+            *args,
+            **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self.master_image_path = master_image_path
+
+    def get_cache_path(
+            self,
+            images: list[np.ndarray],
+            headers: list[astropy.io.fits.Header],
+    ) -> str:
+        return self.master_image_path
+
+
 class BaseCandidateGenerator(BaseProcessor, ImageHandler, ABC):
 
     @classmethod

--- a/winterdrp/processors/bias.py
+++ b/winterdrp/processors/bias.py
@@ -1,6 +1,6 @@
 import numpy as np
 import logging
-from winterdrp.processors.base_processor import ProcessorWithCache
+from winterdrp.processors.base_processor import ProcessorWithCache, ProcessorPremadeCache
 from collections.abc import Callable
 import astropy.io.fits
 from winterdrp.processors.utils.image_selector import select_from_images
@@ -64,3 +64,7 @@ class BiasCalibrator(ProcessorWithCache):
         master_bias = np.nanmedian(biases, axis=2)
 
         return master_bias, headers[0]
+
+
+class MasterBiasCalibrator(ProcessorPremadeCache, BiasCalibrator):
+    pass

--- a/winterdrp/processors/dark.py
+++ b/winterdrp/processors/dark.py
@@ -5,7 +5,7 @@ import os
 import logging
 import pandas as pd
 from collections.abc import Callable
-from winterdrp.processors.base_processor import ProcessorWithCache
+from winterdrp.processors.base_processor import ProcessorWithCache, ProcessorPremadeCache
 from winterdrp.paths import base_name_key
 from winterdrp.processors.utils.image_selector import select_from_images
 
@@ -70,3 +70,7 @@ class DarkCalibrator(ProcessorWithCache):
         master_dark = np.nanmedian(darks, axis=2)
 
         return master_dark, headers[0]
+
+
+class MasterDarkCalibrator(ProcessorPremadeCache, DarkCalibrator):
+    pass

--- a/winterdrp/processors/flat.py
+++ b/winterdrp/processors/flat.py
@@ -2,7 +2,7 @@ import astropy.io.fits
 import numpy as np
 import logging
 import sys
-from winterdrp.processors.base_processor import ProcessorWithCache
+from winterdrp.processors.base_processor import ProcessorWithCache, ProcessorPremadeCache
 from winterdrp.processors.utils.image_selector import select_from_images
 from collections.abc import Callable
 from winterdrp.paths import latest_save_key, flat_frame_key
@@ -103,7 +103,8 @@ class SkyFlatCalibrator(FlatCalibrator):
     ) -> tuple[list[np.ndarray], list[astropy.io.fits.Header]]:
         return select_from_images(images, headers, header_key="obsclass", target_values="science")
 
-
+class MasterFlatCalibrator(ProcessorPremadeCache, FlatCalibrator):
+    pass
 # class OldSkyFlatCalibrator(SkyFlatCalibrator):
 #
 #     def select_cache_images(

--- a/winterdrp/processors/sky.py
+++ b/winterdrp/processors/sky.py
@@ -5,7 +5,7 @@ import logging
 import pandas as pd
 from collections.abc import Callable
 from astropy.time import Time
-from winterdrp.processors.base_processor import ProcessorWithCache
+from winterdrp.processors.base_processor import ProcessorWithCache, ProcessorPremadeCache
 from winterdrp.processors.flat import SkyFlatCalibrator
 from winterdrp.paths import cal_output_dir, saturate_key
 
@@ -42,7 +42,8 @@ class NightSkyMedianCalibrator(SkyFlatCalibrator):
 
         return images, headers
 
-
+class MasterSkyCalibrator(ProcessorPremadeCache, NightSkyMedianCalibrator):
+    pass
 # class OldNightSkyMedianCalibrator(
 #     NightSkyMedianCalibrator,
 #     OldSkyFlatCalibrator


### PR DESCRIPTION
Create new ProcessorPrebuiltCache, which inherits from ProcessorWithCache, except that you specify the path to a pre-created master image. This Processor can be used, with mixed inheritance, to create processors such as the MasterFlatCalibrator, which uses a pre-built master flat.