### PR TITLE
Set SSH_USER env option

### DIFF
--- a/env.example
+++ b/env.example
@@ -15,3 +15,6 @@ kowalski_pwd=<password>
 # Used by SendToFritz
 FRITZ_TOKEN=<token>
 FRITZ_AUTHID=<id>
+
+# Used as default user for ssh/rsyncing in winterdrp/downloader
+SSH_USER=<user>

--- a/winterdrp/downloader/caltech.py
+++ b/winterdrp/downloader/caltech.py
@@ -1,5 +1,6 @@
 import os
 import logging
+import os
 from winterdrp.paths import raw_img_dir
 
 
@@ -12,9 +13,11 @@ def download_via_ssh(
         night: str | int,
         pipeline: str,
         prefix: str = "",
-        server_sub_dir: str = None
+        server_sub_dir: str = None,
+        username: str = os.getenv("SSH_USER")
 ):
-    username = input(f"Please enter your username for {server}: \n")
+    if username is None:
+        username = input(f"Please enter your username for {server}: \n")
 
     source_dir = f"{username}@{server}:{os.path.join(base_dir, prefix+night)}/"
 


### PR DESCRIPTION
Add option to specify SSH user via environment variable. If paired with passwordless ssh, makes copying data very convenient.