### PR TITLE
Automatically pull latest test data then select correct tag

### DIFF
--- a/winterdrp/downloader/get_test_data.py
+++ b/winterdrp/downloader/get_test_data.py
@@ -16,6 +16,8 @@ test_data_dir = os.path.join(
     os.path.basename(TEST_DATA_URL.replace(".git", ""))
 )
 
+TEST_DATA_TAG = "v0.1.0"
+
 
 def get_test_data_dir() -> str:
 
@@ -26,6 +28,22 @@ def get_test_data_dir() -> str:
         logger.info(f"No test data found. Downloading. Executing: {cmd}")
 
         os.system(cmd)
+
+    else:
+        cmds = [
+            f"git -C {test_data_dir} checkout main",
+            f"git -C {test_data_dir} pull"
+        ]
+
+        for cmd in cmds:
+            logger.info(f"Trying to update test data. Executing: {cmd}")
+            os.system(cmd)
+
+    fix_version_cmd = f"git -C {test_data_dir} checkout -d tags/{TEST_DATA_TAG}"
+
+    logger.info(f"Checkout out correct test data commit. Executing: {fix_version_cmd}")
+
+    os.system(fix_version_cmd)
 
     return test_data_dir
 


### PR DESCRIPTION
Versioning test data could be a mess. My solution: git pull to always have the latest test data. Then checkout a version of the testdata which is specified in winterdrp. If a newer version of testdata is created, the winterdrp tests will still choose the old testdata version until the winterdrp code is updated to match.