### PR TITLE
RawPath to reflect stacking

### DIFF
--- a/winterdrp/processors/astromatic/swarp/swarp.py
+++ b/winterdrp/processors/astromatic/swarp/swarp.py
@@ -3,7 +3,8 @@ import os
 import numpy as np
 import astropy.io.fits
 from winterdrp.processors.base_processor import BaseImageProcessor
-from winterdrp.paths import get_output_dir, copy_temp_file, get_temp_path, base_name_key, latest_mask_save_key
+from winterdrp.paths import get_output_dir, copy_temp_file, get_temp_path, base_name_key, latest_mask_save_key, \
+    raw_img_key
 from winterdrp.utils import execute
 from winterdrp.processors.astromatic.scamp.scamp import Scamp, scamp_header_key
 from astropy.wcs import WCS
@@ -305,7 +306,8 @@ class Swarp(BaseImageProcessor):
                 os.remove(temp_file)
                 logger.debug(f"Deleted temporary file {temp_file}")
 
-        new_header[base_name_key] = ",".join([x[base_name_key] for x in headers])
+        new_header[raw_img_key] = ",".join([x[raw_img_key] for x in headers])
+        new_header[base_name_key] = os.path.basename(output_image_path)
         new_header[latest_mask_save_key] = os.path.basename(output_image_weight_path)
         return [image], [new_header]
 

--- a/winterdrp/processors/astromatic/swarp/swarp.py
+++ b/winterdrp/processors/astromatic/swarp/swarp.py
@@ -104,8 +104,8 @@ class Swarp(BaseImageProcessor):
             center_dec: float = None,
             gain: float = None,
             include_scamp: bool = True,
-            combine: bool =False,
-            cache: bool =False,
+            combine: bool = False,
+            cache: bool = False,
             subtract_bkg: bool = False,
             *args,
             **kwargs
@@ -167,8 +167,6 @@ class Swarp(BaseImageProcessor):
             )
         logger.debug(f"Saving to {output_image_path}")
 
-        out_files = []
-
         all_pixscales = []
         all_imgpixsizes = []
         all_ras = []
@@ -177,9 +175,19 @@ class Swarp(BaseImageProcessor):
             for i, data in enumerate(images):
                 header = headers[i]
 
-                pixscale_to_use, x_imgpixsize_to_use, y_imgpixsize_to_use, center_ra_to_use, center_dec_to_use = None, None, None, None, None
+                pixscale_to_use = None
+                x_imgpixsize_to_use = None
+                y_imgpixsize_to_use = None
+                center_ra_to_use = None
+                center_dec_to_use = None
 
-                if not ((self.pixscale is None) | (self.x_imgpixsize is None) | (self.y_imgpixsize is None) | (self.center_ra is None) | (self.center_dec is None)):
+                if not (
+                        (self.pixscale is None) |
+                        (self.x_imgpixsize is None) |
+                        (self.y_imgpixsize is None) |
+                        (self.center_ra is None) |
+                        (self.center_dec is None)
+                ):
                     pixscale_to_use = self.pixscale
                     x_imgpixsize_to_use = self.x_imgpixsize
                     y_imgpixsize_to_use = self.y_imgpixsize
@@ -187,25 +195,32 @@ class Swarp(BaseImageProcessor):
                     center_dec_to_use = self.center_dec
                 else:
                     w = WCS(header)
+
                     cd11 = header['CD1_1']
                     cd21 = header['CD2_1']
                     cd12 = header['CD1_2']
                     cd22 = header['CD2_2']
+
                     nxpix = header['NAXIS1']
                     nypix = header['NAXIS2']
+
                     image_x_cen = nxpix / 2
                     image_y_cen = nypix / 2
+
                     [ra, dec] = w.all_pix2world(image_x_cen, image_y_cen, 1)
+
                     xscale = np.sqrt(cd11 ** 2 + cd21 ** 2)
                     yscale = np.sqrt(cd12 ** 2 + cd22 ** 2)
 
                     pixscale = xscale * 3600
                     imgpixsize = max(nxpix, nypix)
+
                     all_pixscales.append(pixscale)
                     all_imgpixsizes.append(imgpixsize)
                     all_ras.append(ra)
                     all_decs.append(dec)
-                logger.info(f"{all_ras}, {all_decs}")
+
+                logger.debug(f"{all_ras}, {all_decs}")
 
                 if self.include_scamp:
                     temp_head_path = copy_temp_file(
@@ -213,8 +228,10 @@ class Swarp(BaseImageProcessor):
                         file_path=str(header[scamp_header_key]).replace('\n', '')
                     )
 
-                temp_img_path = get_temp_path(swarp_output_dir, header["BASENAME"])
+                temp_img_path = get_temp_path(swarp_output_dir, header[base_name_key])
+
                 self.save_fits(data, header, temp_img_path)
+
                 temp_mask_path = self.save_mask(data, header, temp_img_path)
 
                 f.write(f"{temp_img_path}\n")
@@ -224,8 +241,6 @@ class Swarp(BaseImageProcessor):
                     temp_files += [temp_head_path, temp_img_path, temp_mask_path]
                 else:
                     temp_files += [temp_img_path, temp_mask_path]
-
-                # out_files.append(out_path)
 
         if pixscale_to_use is None:
             pixscale_to_use = np.max(all_pixscales)
@@ -264,9 +279,10 @@ class Swarp(BaseImageProcessor):
 
             temp_output_image_path = get_temp_path(
                 swarp_output_dir,
-                os.path.splitext(headers[0]["BASENAME"])[0] + ".resamp.fits"
+                os.path.splitext(headers[0][base_name_key])[0] + ".resamp.fits"
             )
             temp_output_image_weight_path = temp_output_image_path.replace(".fits", ".weight.fits")
+
             if os.path.exists(temp_output_image_path):
                 os.rename(temp_output_image_path, output_image_path)
                 os.rename(temp_output_image_weight_path, output_image_weight_path)
@@ -289,7 +305,7 @@ class Swarp(BaseImageProcessor):
                 os.remove(temp_file)
                 logger.debug(f"Deleted temporary file {temp_file}")
 
-        new_header[base_name_key] = os.path.basename(output_image_path)
+        new_header[base_name_key] = ",".join([x[base_name_key] for x in headers])
         new_header[latest_mask_save_key] = os.path.basename(output_image_weight_path)
         return [image], [new_header]
 

--- a/winterdrp/processors/base_processor.py
+++ b/winterdrp/processors/base_processor.py
@@ -11,7 +11,7 @@ import pandas as pd
 
 from winterdrp.io import save_to_path, open_fits
 from winterdrp.paths import cal_output_sub_dir, get_mask_path, latest_save_key, latest_mask_save_key, get_output_path,\
-    base_name_key, proc_history_key
+    base_name_key, proc_history_key, raw_img_key
 from winterdrp.errors import ErrorReport, ErrorStack, ProcessorError, NoncriticalProcessingError
 
 logger = logging.getLogger(__name__)
@@ -138,7 +138,7 @@ class ImageHandler:
         return hashlib.sha1(key.encode()).hexdigest()
 
     def image_batch_error_report(self, exception: Exception, batch):
-        contents = (",".join([x[base_name_key] for x in batch[1]])).split(",")
+        contents = (",".join([x[raw_img_key] for x in batch[1]])).split(",")
         return ErrorReport(exception, self.__module__, contents)
 
 

--- a/winterdrp/processors/base_processor.py
+++ b/winterdrp/processors/base_processor.py
@@ -138,7 +138,7 @@ class ImageHandler:
         return hashlib.sha1(key.encode()).hexdigest()
 
     def image_batch_error_report(self, exception: Exception, batch):
-        contents = [x[base_name_key] for x in batch[1]]
+        contents = ",".join([x[base_name_key] for x in batch[1]]).split(",")
         return ErrorReport(exception, self.__module__, contents)
 
 

--- a/winterdrp/processors/base_processor.py
+++ b/winterdrp/processors/base_processor.py
@@ -8,6 +8,7 @@ import getpass
 import datetime
 import hashlib
 import pandas as pd
+from pathlib import Path
 
 from winterdrp.io import save_to_path, open_fits
 from winterdrp.paths import cal_output_sub_dir, get_mask_path, latest_save_key, latest_mask_save_key, get_output_path,\
@@ -138,7 +139,7 @@ class ImageHandler:
         return hashlib.sha1(key.encode()).hexdigest()
 
     def image_batch_error_report(self, exception: Exception, batch):
-        contents = [os.path.basename(x) for x in ",".join([x[raw_img_key] for x in batch[1]]).split(",")]
+        contents = [Path(x).name for x in ",".join([x[raw_img_key] for x in batch[1]]).split(",")]
         return ErrorReport(exception, self.__module__, contents)
 
 

--- a/winterdrp/processors/base_processor.py
+++ b/winterdrp/processors/base_processor.py
@@ -138,7 +138,7 @@ class ImageHandler:
         return hashlib.sha1(key.encode()).hexdigest()
 
     def image_batch_error_report(self, exception: Exception, batch):
-        contents = ",".join([x[base_name_key] for x in batch[1]]).split(",")
+        contents = (",".join([x[base_name_key] for x in batch[1]])).split(",")
         return ErrorReport(exception, self.__module__, contents)
 
 

--- a/winterdrp/processors/base_processor.py
+++ b/winterdrp/processors/base_processor.py
@@ -138,7 +138,7 @@ class ImageHandler:
         return hashlib.sha1(key.encode()).hexdigest()
 
     def image_batch_error_report(self, exception: Exception, batch):
-        contents = (",".join([x[raw_img_key] for x in batch[1]])).split(",")
+        contents = [os.path.basename(x) for x in ",".join([x[raw_img_key] for x in batch[1]]).split(",")]
         return ErrorReport(exception, self.__module__, contents)
 
 

--- a/winterdrp/processors/reference.py
+++ b/winterdrp/processors/reference.py
@@ -5,7 +5,7 @@ import numpy as np
 from winterdrp.processors.base_processor import BaseImageProcessor
 from astropy.io import fits
 from winterdrp.paths import get_output_dir, copy_temp_file, base_name_key, sextractor_header_key, latest_mask_save_key, \
-    raw_img_dir, psfex_header_key, norm_psfex_header_key
+    raw_img_dir, psfex_header_key, norm_psfex_header_key, raw_img_key
 from winterdrp.references.base_reference_generator import BaseReferenceGenerator
 from collections.abc import Callable
 from winterdrp.processors.astromatic.swarp.swarp import Swarp
@@ -67,11 +67,14 @@ class Reference(BaseImageProcessor):
             ref_image = self.ref_image_generator(header)
             ref_image_path = ref_image.write_reference(header=header, output_dir=self.get_sub_output_dir())
 
-            ref_data, ref_header = self.open_fits(ref_image_path)
+            ref_data, ref_header = open_fits(ref_image_path)
 
             if not (base_name_key in ref_header.keys()):
                 logger.debug(os.path.basename(ref_image_path))
                 ref_header[base_name_key] = os.path.basename(ref_image_path)
+
+            if not (raw_img_key in ref_header.keys()):
+                ref_header[raw_img_key] = ref_image_path
 
             # ref_header[base_name_key] = ref_header[base_name_key] + '_ref'
             ref_gain = ref_header['GAIN']

--- a/winterdrp/processors/reference.py
+++ b/winterdrp/processors/reference.py
@@ -67,7 +67,7 @@ class Reference(BaseImageProcessor):
             ref_image = self.ref_image_generator(header)
             ref_image_path = ref_image.write_reference(header=header, output_dir=self.get_sub_output_dir())
 
-            ref_data, ref_header = open_fits(ref_image_path)
+            ref_data, ref_header = self.open_fits(ref_image_path)
 
             if not (base_name_key in ref_header.keys()):
                 logger.debug(os.path.basename(ref_image_path))


### PR DESCRIPTION
Right now each image has exactly one basename. The basename is used for e.g error tracking. With this PR, we swap to a mode where the basename is a comma-separated list that can be one or more file names. That is important because it means we can flag all original raw images as having an error, if that error applies to the downstream stack.