### PR TITLE
sedmv2 configurations and MEF checks for .fz

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -376,7 +376,7 @@ python-versions = "*"
 
 [[package]]
 name = "beautifulsoup4"
-version = "4.12.1"
+version = "4.12.2"
 description = "Screen-scraping library"
 category = "main"
 optional = false
@@ -942,7 +942,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "importlib-metadata"
-version = "6.1.0"
+version = "6.2.0"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
@@ -1433,7 +1433,6 @@ packaging = ">=20.0"
 pillow = ">=6.2.0"
 pyparsing = ">=2.3.1"
 python-dateutil = ">=2.7"
-setuptools_scm = ">=7"
 
 [[package]]
 name = "matplotlib-inline"
@@ -2371,24 +2370,6 @@ testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-202
 testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
-name = "setuptools-scm"
-version = "7.1.0"
-description = "the blessed package to manage your versions by scm tags"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-
-[package.dependencies]
-packaging = ">=20.0"
-setuptools = "*"
-tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
-typing-extensions = "*"
-
-[package.extras]
-test = ["pytest (>=6.2)", "virtualenv (>20)"]
-toml = ["setuptools (>=42)"]
-
-[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -3090,8 +3071,8 @@ backcall = [
     {file = "backcall-0.2.0.tar.gz", hash = "sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e"},
 ]
 beautifulsoup4 = [
-    {file = "beautifulsoup4-4.12.1-py3-none-any.whl", hash = "sha256:e44795bb4f156d94abb5fbc56efff871c1045bfef72e9efe77558db9f9616ac3"},
-    {file = "beautifulsoup4-4.12.1.tar.gz", hash = "sha256:c7bdbfb20a0dbe09518b96a809d93351b2e2bcb8046c0809466fa6632a10c257"},
+    {file = "beautifulsoup4-4.12.2-py3-none-any.whl", hash = "sha256:bd2520ca0d9d7d12694a53d44ac482d181b4ec1888909b035a3dbf40d0f57d4a"},
+    {file = "beautifulsoup4-4.12.2.tar.gz", hash = "sha256:492bbc69dca35d12daac71c4db1bfff0c876c00ef4a2ffacce226d4638eb72da"},
 ]
 black = [
     {file = "black-23.3.0-cp310-cp310-macosx_10_16_arm64.whl", hash = "sha256:0945e13506be58bf7db93ee5853243eb368ace1c08a24c65ce108986eac65915"},
@@ -3576,6 +3557,17 @@ ephem = [
     {file = "ephem-4.1.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:4039aa2f0b8c204283fc478551d8b29c9473137ad8a910a5ff60ae3be6593c7b"},
     {file = "ephem-4.1.4-cp310-cp310-win32.whl", hash = "sha256:8979429643ac4e29a5496321c9c41a20cd7a6a530aee9865c7fab0008450ef28"},
     {file = "ephem-4.1.4-cp310-cp310-win_amd64.whl", hash = "sha256:589a2235f49232b92ee0247923360a264086a57b2c39d4191348f95ba5ce0c3d"},
+    {file = "ephem-4.1.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:feab5f68ae9fa622d6316790c9cfc399e8b78f7958a61da4edf2cb5e0e675d44"},
+    {file = "ephem-4.1.4-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:df9c482c8d25e69271311606b4de0e177e44ceb11781c7ebacf17cc5b391f832"},
+    {file = "ephem-4.1.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1cceea883856817f3ea3f73442e3be3a4a56558cdb77cc85d02db4429ce5ab16"},
+    {file = "ephem-4.1.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f3e9ea626bc522fd4dd1ff795f0922fcb4c4eb57effe91b6284411166ddd1fd7"},
+    {file = "ephem-4.1.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aad22e769bd35415cad8f2ef6d4d875190d9bdad4fed2842fd19dac6f1ccb9dd"},
+    {file = "ephem-4.1.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:e3327218495235ec215ffe43253c0bf3fa982f59504b351c53b024f1c7b63752"},
+    {file = "ephem-4.1.4-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:d2c56238a1aec72a78ad7061f5c531df97a66ea0cca45204b6b8141c3bb1540e"},
+    {file = "ephem-4.1.4-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:fffe176bd94f4f61be5a54b54a966988cceb6ba69a6ed729aab166020fdb37c3"},
+    {file = "ephem-4.1.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8f9b27117e7a82f7f70db9cb23b5cc36d37b166a2f73c55e14d7225d0ab95afa"},
+    {file = "ephem-4.1.4-cp311-cp311-win32.whl", hash = "sha256:9bb21c0b117c9122c0141b0a71ee6fbbb087ed2aab4a7ab60f009e95e9f4a521"},
+    {file = "ephem-4.1.4-cp311-cp311-win_amd64.whl", hash = "sha256:55d7fb5c34b2e453e01fa4ca7ee375b19b438c9401ae8c4099ae4a3a37656972"},
     {file = "ephem-4.1.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:40067fc050c946c8d4c2d779805b61f063471a091e6124cbabcf61ac538011b2"},
     {file = "ephem-4.1.4-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7e2abe97aa2b091090012768b4d94793213cc01f0bf040dcc311a380ab08df69"},
     {file = "ephem-4.1.4-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b2677d3a5b42aedc578de10b0eecdba6a50731f159cb28f7ad38c5f62143494"},
@@ -3803,8 +3795,8 @@ imagesize = [
     {file = "imagesize-1.4.1.tar.gz", hash = "sha256:69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-6.1.0-py3-none-any.whl", hash = "sha256:ff80f3b5394912eb1b108fcfd444dc78b7f1f3e16b16188054bd01cb9cb86f09"},
-    {file = "importlib_metadata-6.1.0.tar.gz", hash = "sha256:43ce9281e097583d758c2c708c4376371261a02c34682491a8e98352365aad20"},
+    {file = "importlib_metadata-6.2.0-py3-none-any.whl", hash = "sha256:8388b74023a138c605fddd0d47cb81dd706232569f56c9aca7d9c7fdb54caeba"},
+    {file = "importlib_metadata-6.2.0.tar.gz", hash = "sha256:9127aad2f49d7203e7112098c12b92e4fd1061ccd18548cdfdc49171a8c073cc"},
 ]
 iniconfig = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
@@ -5024,10 +5016,6 @@ send2trash = [
 setuptools = [
     {file = "setuptools-67.6.1-py3-none-any.whl", hash = "sha256:e728ca814a823bf7bf60162daf9db95b93d532948c4c0bea762ce62f60189078"},
     {file = "setuptools-67.6.1.tar.gz", hash = "sha256:257de92a9d50a60b8e22abfcbb771571fde0dbf3ec234463212027a4eeecbe9a"},
-]
-setuptools-scm = [
-    {file = "setuptools_scm-7.1.0-py3-none-any.whl", hash = "sha256:73988b6d848709e2af142aa48c986ea29592bbcfca5375678064708205253d8e"},
-    {file = "setuptools_scm-7.1.0.tar.gz", hash = "sha256:6c508345a771aad7d56ebff0e70628bf2b0ec7573762be9960214730de278f27"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},

--- a/winterdrp/pipelines/sedmv2/config/__init__.py
+++ b/winterdrp/pipelines/sedmv2/config/__init__.py
@@ -39,6 +39,13 @@ sextractor_candidates_config = {
     "cand_det_sextractor_params": os.path.join(astromatic_config_dir, "Scorr.param"),
 }
 
+sextractor_reference_config = {
+    "config_path": os.path.join(astromatic_config_dir, "photomCat.sex"),
+    "parameter_path": os.path.join(astromatic_config_dir, "photom.param"),
+    "filter_path": os.path.join(astromatic_config_dir, "default.conv"),
+    "starnnw_path": os.path.join(astromatic_config_dir, "default.nnw"),
+}
+
 scamp_path = os.path.join(astromatic_config_dir, "scamp.conf")
 
 swarp_config_path = os.path.join(astromatic_config_dir, "config.swarp")

--- a/winterdrp/pipelines/sedmv2/load_sedmv2_image.py
+++ b/winterdrp/pipelines/sedmv2/load_sedmv2_image.py
@@ -101,6 +101,13 @@ def prepare_science(filepath: str) -> str:
         hdr["OBSTYPE"] = "SCIENCE"
         hdr["OBSCLASS"] = "science"
         hdr["PREPTAG"] = 0  # label files that have already run through this function
+
+        # discern transient vs. stellar based on filename
+        if "ZTF2" in filepath:
+            hdr["SOURCE"] = "transient"
+        else:
+            hdr["SOURCE"] = "stellar"
+
         # save to file with 1 extension
         fits.writeto(filepath, data, hdr, overwrite=True)  # pylint: disable=no-member
     return filepath
@@ -129,6 +136,8 @@ def prepare_cal(filepath: str) -> str:
             hdr0["FILTER"] = f"SDSS {filt}' (Chroma)"
         if hdr0["IMGTYPE"] == "bias":
             hdr0["FILTER"] = "SDSS g"
+
+        hdr0["SOURCE"] = "None"
 
         req_headers = [
             "RA",

--- a/winterdrp/pipelines/sedmv2/sedmv2_pipeline.py
+++ b/winterdrp/pipelines/sedmv2/sedmv2_pipeline.py
@@ -9,7 +9,13 @@ import numpy as np
 
 from winterdrp.downloader.caltech import download_via_ssh
 from winterdrp.pipelines.base_pipeline import Pipeline
-from winterdrp.pipelines.sedmv2.blocks import cal_hunter, imsub, load_raw, process_raw
+from winterdrp.pipelines.sedmv2.blocks import (
+    cal_hunter,
+    load_raw,
+    process,
+    process_stellar,
+    process_transient,
+)
 from winterdrp.pipelines.sedmv2.config import PIPELINE_NAME, sedmv2_cal_requirements
 from winterdrp.pipelines.sedmv2.load_sedmv2_image import load_raw_sedmv2_image
 
@@ -28,8 +34,9 @@ class SEDMv2Pipeline(Pipeline):
     non_linear_level = 30000  # no idea, for pylint
     default_cal_requirements = sedmv2_cal_requirements
     all_pipeline_configurations = {
-        "default": load_raw + cal_hunter + process_raw,
-        "imsub": imsub,
+        "default": load_raw + cal_hunter + process,
+        "default_stellar": load_raw + cal_hunter + process_stellar,  # +image_photometry
+        "default_transient": load_raw + cal_hunter + process_transient,  # +imsub,
     }
 
     @staticmethod

--- a/winterdrp/processors/utils/multi_ext_parser.py
+++ b/winterdrp/processors/utils/multi_ext_parser.py
@@ -15,6 +15,7 @@ from winterdrp.errors import ImageNotFoundError
 from winterdrp.io import open_fits
 from winterdrp.paths import RAW_IMG_SUB_DIR, base_raw_dir
 from winterdrp.processors.base_processor import BaseImageProcessor
+from winterdrp.processors.utils.image_loader import unzip
 
 logger = logging.getLogger(__name__)
 
@@ -99,6 +100,13 @@ def load_from_dir(
     """
 
     img_list = sorted(glob(f"{input_dir}/*.fits"))
+
+    # check for zipped files too
+    zipped_list = sorted(glob(f"{input_dir}/*.fz"))
+    if len(zipped_list) > 0:
+        unzipped_list = unzip(zipped_list)
+        for file in unzipped_list:
+            img_list.append(file)
 
     logger.info(f"Loading from {input_dir}, with {len(img_list)} images")
 


### PR DESCRIPTION
This PR introduces new configurations for the SEDMv2 Pipeline. 
* `default` has the same functionality we already know and love (process all raw files in a given folder, all following the same steps).
    
* Introducing… `default_stellar` and `default_transient`! These will only run on stellar or transient sources respectively, using file names to discern the two types (file name → new header keyword `SOURCE` that can be `stellar`, `transient`, or `None` for calibration files). They follow similar steps, diverging at Swarp (transients get stacked and stellar sources do not). Moving forward, we can experiment with stellar-specific processors in the `default_stellar` config (like `ImageAperturePhotometry`, `ImagePSFPhotometry`) and transient-specific processors in `default_transient` (like image subtraction).
    
Additionally, this PR ensures that `MultiExtParser` checks for zipped files just as `ImageLoader` does.