### PR TITLE
Update swarp imagesize

### DIFF
--- a/winterdrp/pipelines/sedmv2/blocks.py
+++ b/winterdrp/pipelines/sedmv2/blocks.py
@@ -105,6 +105,7 @@ resample = [
         swarp_config_path=swarp_config_path,
         include_scamp=False,
         combine=False,
+        calculate_dims_in_swarp=True,
     ),
     ImageSaver(
         output_dir_name="resampled", write_mask=True

--- a/winterdrp/processors/astromatic/swarp/swarp.py
+++ b/winterdrp/processors/astromatic/swarp/swarp.py
@@ -170,6 +170,7 @@ class Swarp(BaseImageProcessor):
         cache: bool = False,
         subtract_bkg: bool = False,
         flux_scaling_factor: float = None,
+        calculate_dims_in_swarp: bool = False,
     ):
         """
 
@@ -239,6 +240,7 @@ class Swarp(BaseImageProcessor):
         self.gain = gain
         self.subtract_bkg = subtract_bkg
         self.flux_scaling_factor = flux_scaling_factor
+        self.calculate_dims_in_swarp = calculate_dims_in_swarp
 
     def __str__(self) -> str:
         return "Processor to apply swarp to images, stacking them together."
@@ -397,6 +399,10 @@ class Swarp(BaseImageProcessor):
             center_ra_to_use = np.median(all_ras)
         if center_dec_to_use is None:
             center_dec_to_use = np.median(all_decs)
+
+        if self.calculate_dims_in_swarp:
+            x_imgpixsize_to_use = None
+            y_imgpixsize_to_use = None
 
         logger.debug(f"{self.center_ra}, {center_ra_to_use}")
 


### PR DESCRIPTION
In response to issue #340 

I have updated the Swarp processor to allow the user to let Swarp auto-calculate the resampled image size. The new argument `calculate_dims_in_swarp` (default `False`) determines if Swarp calculates the resulting image size automatically if set to `True` . If set to `False` (default) then the resulting image size is the `MAX(Nx, Ny)`.

Also updated the `SEDMv2` pipeline to use this, calculating the resampled image size automatically. 