### PR TITLE
Update sedmv2 astrometry timeout

### DIFF
--- a/winterdrp/pipelines/sedmv2/blocks.py
+++ b/winterdrp/pipelines/sedmv2/blocks.py
@@ -90,6 +90,7 @@ reduce = [
         scale_bounds=(0.1667, 0.0333),
         scale_units="degw",
         downsample=2,
+        timeout=900,
     ),
     MaskPixels(mask_path=sedmv2_mask_path),
     Sextractor(

--- a/winterdrp/processors/anet/anet.py
+++ b/winterdrp/processors/anet/anet.py
@@ -41,6 +41,7 @@ def run_astrometry_net_single(
     scale_bounds: Optional[tuple | list] = None,  # limits on scale (lower, upper)
     scale_units: Optional[str] = None,  # scale units ('degw', 'amw')
     downsample: Optional[float | int] = None,  # downsample by factor of __
+    timeout: Optional[float] = None,  # astrometry cmd execute timeout, in seconds
 ):
     """
     function to run astrometry.net locally on one image, with options to adjust settings
@@ -78,11 +79,19 @@ def run_astrometry_net_single(
     )  # radius takes on units of ra, dec
 
     try:
-        execute(cmd_loc, output_dir)
+        if timeout is not None:
+            execute(cmd_loc, output_dir, timeout=timeout)
+        else:
+            execute(cmd_loc, output_dir)
+
         if os.path.isfile(img):
             logger.info(f"Ran a-net with ra,dec guess. \n A-net command: {cmd_loc}")
         else:
-            execute(cmd, output_dir)
+            if timeout is not None:
+                execute(cmd_loc, output_dir, timeout=timeout)
+            else:
+                execute(cmd_loc, output_dir)
+
             if os.path.isfile(img):
                 logger.info(f"Ran a-net without ra,dec guess. \n A-net command: {cmd}")
     except ExecutionError as err:

--- a/winterdrp/processors/anet/anet_processor.py
+++ b/winterdrp/processors/anet/anet_processor.py
@@ -16,6 +16,9 @@ from winterdrp.processors.base_processor import BaseImageProcessor
 logger = logging.getLogger(__name__)
 
 
+ASTROMETRY_TIMEOUT = 900  # astrometry cmd execute timeout, in seconds
+
+
 class AstrometryNet(BaseImageProcessor):
     """Processor to run astrometry.net"""
 
@@ -27,6 +30,9 @@ class AstrometryNet(BaseImageProcessor):
         scale_bounds: Optional[tuple | list] = None,  # limits on scale (lower, upper)
         scale_units: Optional[str] = None,  # scale units ('degw', 'amw')
         downsample: Optional[float | int] = None,
+        timeout: Optional[
+            float
+        ] = ASTROMETRY_TIMEOUT,  # astrometry cmd execute timeout, in seconds
     ):
         super().__init__()
 
@@ -34,6 +40,7 @@ class AstrometryNet(BaseImageProcessor):
         self.scale_bounds = scale_bounds
         self.scale_units = scale_units
         self.downsample = downsample
+        self.timeout = timeout
 
     def __str__(self) -> str:
         return "Processor to perform astrometric calibration via astrometry.net."
@@ -67,6 +74,7 @@ class AstrometryNet(BaseImageProcessor):
                 scale_bounds=self.scale_bounds,
                 scale_units=self.scale_units,
                 downsample=self.downsample,
+                timeout=self.timeout,
             )
 
             newname = anet_out_dir.joinpath(Path(str(temp_path).split("temp_")[1]))


### PR DESCRIPTION
Update the anet processor to allow for longer default timeout. 

Currently the `utils/execute_cmd/execute` has a default timeout of 300s. It is known that sometimes the anet processor will take longer to successfully solve an image. I have added the `timeout` argument to the `anet` processor, and set the variable `ASTROMETRY_TIMEOUT = 900`.

This updates SEDMv2 pipeline to use 15min (900s) as the default timeout for the anet processor. May need to change as we test more. 