### PR TITLE
Referencing other modules within docs

### DIFF
--- a/winterdrp/data/image_data.py
+++ b/winterdrp/data/image_data.py
@@ -220,9 +220,10 @@ class ImageBatch(DataBatch):
     A subclass of :class:`~winterdrp.data.base_data.DataBatch`,
     which contains :class:`~winterdrp.data.image_data.Image` objects
 
-    To batch, de-batch, and select objects within batches, see the
-    ImageBatcher, ImageDebatcher, and ImageSelector classes in
-    `~winterdrp.processors.utils.image_selector`.
+    To batch, de-batch, and select objects within batches, see
+    :class:`~winterdrp.processors.utils.image_selector.ImageBatcher`,
+    :class:`~winterdrp.processors.utils.image_selector.ImageDebatcher`, and
+    :class:`~winterdrp.processors.utils.image_selector.ImageSelector`.
     """
 
     data_type = Image

--- a/winterdrp/processors/utils/image_selector.py
+++ b/winterdrp/processors/utils/image_selector.py
@@ -178,11 +178,7 @@ class ImageDebatcher(BaseImageProcessor):
     Processor to group all incoming :class:`~winterdrp.data.image_data.ImageBatch`
     objects into a single batch.
     This is helpful if you've already batched at an earlier stage in your workflow, and
-    you want to start over and batch by a different split key. For example:
-        ImageBatcher(split_key=A)
-        ...
-        ImageDebatcher()
-        ImageBatcher(split_key=B)
+    you want to start over and batch by a different split key.
     """
 
     base_key = "debatch"


### PR DESCRIPTION
Add :class: before references to other modules (:class:\`winterdrp...\`) in the new ImageBatch docstring from PR #372 